### PR TITLE
Fix bug where longer running tests are not accounted

### DIFF
--- a/src/Revit.TestRunner.Console/Commands/AbstractTestCommand.cs
+++ b/src/Revit.TestRunner.Console/Commands/AbstractTestCommand.cs
@@ -62,7 +62,7 @@ namespace Revit.TestRunner.Console.Commands
             await client.StartTestRunAsync( cases, RevitVersion.ToString(), result => {
                 try {
                     if( result.StateDto != null ) {
-                        foreach( var test in result.StateDto.Cases.Where( c => c.State != TestState.Unknown ) ) {
+                        foreach( var test in result.StateDto.Cases.Where( c => c.State != TestState.Unknown && c.State != TestState.Running ) ) {
                             if( complete.All( t => t.Id != test.Id ) ) {
                                 complete.Add( test );
 


### PR DESCRIPTION
This fixes a bug in the console runner. The console runner currently ignores the test results of longer running tests