### PR TITLE
Return success/error code from console runner

### DIFF
--- a/src/Revit.TestRunner.Console/Commands/AbstractTestCommand.cs
+++ b/src/Revit.TestRunner.Console/Commands/AbstractTestCommand.cs
@@ -47,9 +47,9 @@ namespace Revit.TestRunner.Console.Commands
         }
 
         /// <summary>
-        /// Run specified Tests.
+        /// Run specified Tests. Returns true if all tests passed.
         /// </summary>
-        protected async Task RunTests( IEnumerable<TestCaseDto> cases, TestRunnerClient client = null )
+        protected async Task<bool> RunTests( IEnumerable<TestCaseDto> cases, TestRunnerClient client = null )
         {
             System.Console.WriteLine( $"Start test run {DateTime.Now}; preferred on Revit {RevitVersion}" );
             System.Console.WriteLine();
@@ -93,6 +93,7 @@ namespace Revit.TestRunner.Console.Commands
 
             System.Console.WriteLine();
             System.Console.WriteLine( $"Run finished - duration {duration:g} - {passedCount} of {completeCount} Tests passed ({Math.Round( 100 * (double)passedCount / completeCount )}%)" );
+            return passedCount == completeCount;
         }
     }
 }

--- a/src/Revit.TestRunner.Console/Commands/AssemblyCommand.cs
+++ b/src/Revit.TestRunner.Console/Commands/AssemblyCommand.cs
@@ -27,15 +27,21 @@ namespace Revit.TestRunner.Console.Commands
         {
             base.Execute();
 
+            var allPassed = false;
             if( FileExist( AssemblyPath ) ) {
-                RunAll( AssemblyPath ).GetAwaiter().GetResult();
+                allPassed = RunAll( AssemblyPath ).GetAwaiter().GetResult();
+            }
+
+            if (!allPassed)
+            {
+                System.Environment.Exit(-1);
             }
         }
 
         /// <summary>
-        /// Run all tests in assembly.
+        /// Run all tests in assembly. Returns true if tests could be loaded and all passed.
         /// </summary>
-        private async Task RunAll( string assemblyPath )
+        private async Task<bool> RunAll( string assemblyPath )
         {
             System.Console.WriteLine( "Run all tests in assembly" );
             System.Console.WriteLine( $"Explore assembly '{AssemblyPath}'" );
@@ -48,8 +54,10 @@ namespace Revit.TestRunner.Console.Commands
                 var root = ModelHelper.ToNodeTree( explore.ExploreFile );
                 var cases = root.DescendantsAndMe.Where( n => n.Type == TestType.Case ).ToArray();
 
-                await RunTests( cases.Select( ModelHelper.ToTestCase ), client );
+                return await RunTests( cases.Select( ModelHelper.ToTestCase ), client );
             }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
In order to run the testrunner in a automated build/test pipeline we need some feedback if the tests passed.

The console runner now sets the exit code to -1 if some tests fail